### PR TITLE
Update plugins.yaml

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -275,7 +275,7 @@ CascadePID:
   repo_url: https://github.com/jangevaare/cbpi-CascadePID.git
 
 OneWireAdvanced:
-  description: This CraftBeerPi 3.0 plugin provides a new sensor type called OneWireAdvanced. This plugin attempts to provide even more control over DS18B20 temperature readings in CraftBeerPi. It allows setting of: sensor bias, low and high value filters, update interval, and an option for alerts when values are filtered.
+  description: "This CraftBeerPi 3.0 plugin provides a new sensor type called OneWireAdvanced. This plugin attempts to provide even more control over DS18B20 temperature readings in CraftBeerPi. It allows setting of: sensor bias, low and high value filters, update interval, and an option for alerts when values are filtered."
   api: 3.0
   author: Justin Angevaare
   repo_url: https://github.com/jangevaare/cbpi-OneWireAdvanced.git


### PR DESCRIPTION
One wire advanced description contains a colon so needs to to have quotes around it.

All descriptions should probably be updated in future but this is a quick fix