### PR TITLE
Add Nextion Display

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -417,3 +417,9 @@ ModMeshStep:
   api: 3.0
   author: Miha Zivkovic
   repo_url: https://github.com/exoticatom/ModMashStep.git
+
+NextionDisplay:
+  description: Connect a Nextion 3.5" display, shows charts of selcted kettle/fermenter, watch up to 4 kettle at once
+  api: 3.0
+  author: Jan Battermann
+  repo_url: https://github.com/JamFfm/NEXTIONDisplay.git


### PR DESCRIPTION
Have a look at https://github.com/JamFfm/NEXTIONDisplay
Basically it displays some date of the CBPi3 on a Nextion Display via Serial Connection.
Initially it should provide temperature Graphs in Addition to the LCD Display. But now it provides all Information of the LCD Displa too (besides Multi Fermentation mode)